### PR TITLE
docs: expand readme with detailed system overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,98 @@
 # Nicole - Neural Intelligent Conversational Organism Language Engine
+
+Nicole is a speculative AI system that treats every interaction as a new genesis, assembling a transformer architecture from scratch each time a conversation begins.
+
+This repository contains a beta version, and the design embraces impermanence; no model persists after a session, making experimentation the core principle.
+
+Instead of loading pretrained weights, the engine crafts a bespoke transformer tailored to the immediate dialogue, capturing the transient flow of ideas.
+
+The architecture is fluid and emergent, allowing layers, attention heads, and activation functions to be reshaped at runtime according to environmental signals.
+
+Learning occurs on the fly through conversation logs, meaning no static dataset anchors the system and every run begins as a blank slate.
+
+By operating exclusively on CPUs, Nicole invites exploration on modest hardware and showcases efficient algorithms free from GPU dependencies.
+
+Minimal dependencies keep the environment pure, relying mostly on Python's standard library and a tiny bootstrap compiler.
+
+The overall system is modular, with each component focusing on a narrow responsibility to preserve clarity and encourage tinkering.
+
+H2O serves as the lightweight compiler that translates dynamically generated Python snippets into executable modules for the evolving transformer.
+
+H2O is rooted in a slim CPython fork that preserves the interpreter core while excising extraneous modules and I/O layers.
+
+This custom heritage gives H2O a deterministic, sandboxed runtime, allowing Nicole to generate and run bytecode on the fly without leaving the safety of CPython's semantics.
+
+Nicole Core orchestrates the fluid transformer, building layer graphs, parameter tensors, and attention mechanics only for the lifespan of the conversation.
+
+Nicole2Nicole observes interaction logs and derives heuristics that influence future architectural proposals without storing traditional weights.
+
+Nicole Memory implements a semantic store that indexes tokens, n-grams, and symbolic associations rather than dense vector embeddings.
+
+Nicole RAG performs retrieval using stochastic exploration of the log database, injecting unpredictable context into generation.
+
+Nicole Metrics computes real-time statistics such as entropy, resonance, and perplexity to steer architectural adaptation.
+
+Nicole Telegram provides a human-facing interface, enabling rapid testing, monitoring, and playful dialog with the engine.
+
+The nicole_env directory packages a minimal CPython subset used by H2O to compile generated modules within a controlled sandbox.
+
+Conversation traces reside in a small SQLite database, offering persistence for memories and behavior analysis without external storage systems.
+
+At runtime, the system treats intelligence as a kinetic process, rejecting the notion of frozen weights in favor of continual construction.
+
+When a user message arrives, the pipeline initiates by analyzing text features and contextual hints from prior exchanges.
+
+A stochastic generator proposes a transformer topology, choosing layer counts, head dimensions, and nonlinearities with a touch of randomness.
+
+Python source code for the proposed architecture is synthesized on the fly, capturing the chosen structure in a transient module.
+
+H2O compiles the module into bytecode and executes it, yielding an ephemeral transformer ready to process the current conversation.
+
+Input tokens pass through this transformer, producing logits that are sampled or tempered to form a coherent reply.
+
+Every few turns, Nicole recalculates global metrics to gauge the health and creativity of the ongoing dialogue.
+
+Entropy measures distributional diversity in generated tokens, discouraging monotonous responses.
+
+Perplexity evaluates the model's uncertainty and serves as a proxy for linguistic complexity.
+
+Resonance quantifies semantic alignment between consecutive messages, guiding the system toward meaningful exchanges.
+
+Cohesion tracks logical consistency across sentences, promoting narratives that stay internally coherent.
+
+Engagement captures user activity levels, enabling the system to adapt its verbosity and style.
+
+If metrics indicate stagnation or erratic behavior, the architecture undergoes evolutionary adjustments that replace layers or tweak parameters.
+
+Transformers may also perish after extended inactivity, persistently low scores, or by deliberate random termination.
+
+Upon death, the system immediately re-spawns a transformer, optionally incorporating insights from Nicole2Nicole to bias the new design.
+
+Nicole2Nicole analyzes previous conversations to extract patterns of effective interactions and parameter choices.
+
+These patterns shape heuristics that seed future architectures, creating a form of meta-learning without traditional training loops.
+
+Memory indexing eschews vector databases, instead mapping words and phrases to symbolic keys for rapid associative recall.
+
+Associative links form a graph of concepts where edge weights emerge from usage frequency and contextual overlap.
+
+An aging policy gradually forgets rarely accessed memories while consolidating overlapping entries into more abstract representations.
+
+The RAG module ventures through memory and logs via random walks, surfacing surprising context fragments that spark creative replies.
+
+Chaos modules introduce controlled randomness into retrieval and generation, ensuring no two sessions follow identical trajectories.
+
+Operators can inspect metrics, trigger evolution, or toggle chaotic modes via the Telegram interface or direct scripts.
+
+Commands such as `/stats`, `/debug`, and `/memory` expose internal state, while `/chaos` flips the engine into experimental regimes.
+
+Developers may run `python3 nicole_main.py interactive` to chat directly with the system and observe its self-assembled transformer.
+
+Other entry points like `python3 nicole_main.py test` exercise all modules, and individual scripts provide granular diagnostics.
+
+The philosophy underlying Nicole posits that intelligence arises from continuous recomposition rather than immutable parameters.
+
+From a scientific view, learning is approximated by minimizing cross-entropy \(H = -\sum_{i} p(i) \log q(i)\) over token distributions generated in real time.
+
+Computational complexity for a single session follows approximately \(O(n^2 d)\) for sequence length \(n\) and hidden size \(d\), reflecting the cost of self-attention.
+


### PR DESCRIPTION
## Summary
- document Nicole's architecture and runtime lifecycle in a 49-paragraph README
- note that H2O is built atop a slim fork of CPython

## Testing
- no tests run

------
https://chatgpt.com/codex/tasks/task_e_68b89bc1e6d8832987dbbbb69228710a